### PR TITLE
Fixed fog for particles and armor

### DIFF
--- a/assets/minecraft/shaders/core/particle.vsh
+++ b/assets/minecraft/shaders/core/particle.vsh
@@ -24,7 +24,7 @@ out vec4 maxLightColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
     texCoord0 = UV0;
     vertexColor = Color;
 	lightColor = minecraft_sample_lightmap(Sampler2, UV2);

--- a/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.json
+++ b/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.json
@@ -1,0 +1,33 @@
+{
+    "blend": {
+        "func": "add",
+        "srcrgb": "srcalpha",
+        "dstrgb": "1-srcalpha"
+    },
+    "vertex": "rendertype_armor_cutout_no_cull",
+    "fragment": "rendertype_armor_cutout_no_cull",
+    "attributes": [
+        "Position",
+        "Color",
+        "UV0",
+        "UV1",
+        "UV2",
+        "Normal"
+    ],
+    "samplers": [
+        { "name": "Sampler0" },
+        { "name": "Sampler2" }
+    ],
+    "uniforms": [
+        { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "IViewRotMat", "type": "matrix3x3", "count": 9, "values": [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
+        { "name": "Light0_Direction", "type": "float", "count": 3, "values": [0.0, 0.0, 0.0] },
+        { "name": "Light1_Direction", "type": "float", "count": 3, "values": [0.0, 0.0, 0.0] },
+        { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
+        { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
+        { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
+        { "name": "FogShape", "type": "int", "count": 1, "values": [ 0 ] }
+    ]
+}


### PR DESCRIPTION
Previously, particles and armor would show through fog, an easy example is to give yourself the blindness effect and get some distance to a particle or an armor stand with armor.

This had two reasons:
1. Particles don't need `IViewRotMat`, so the particle JSON didn't provide it, and using it results in incorrect calculations. So that was removed from the calculation.
2. The default resource pack has a bug where the armor shader doesn't have `IViewRotMat` applied, so they didn't add this in the JSON. This pack had been using `IViewRotMat` without defining it in the JSON, so it was apparently defaulting to `mat3(0)`.

Both of these aspects are fixed with this branch.