### PR TITLE
a few features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Translucent textures require a bit more work. Check the example for ice to get a
 `return inputColor;` means you're returning the color of the texture without any lighting applied. This is used for making something fully emissive.
 `return apply_partial_emissivity();` means the blocks with that alpha are only partially emissive, tinting it with a specific color of light. You can find a handy link to a table of light colors here: https://minecraft.fandom.com/wiki/Light?file=1.9_lighting_curves_%2528gamma%253D0%2529.png. Remember, colors in OpenGL are formatted as RGB values from 0 to 1!
 `return inputColor * lightColor;` means you're simply returning the texture with its proper lighting. This is the default case.
-You can do `return inputColor * maxLightColor;` if you change the lightmap in any way in order to make emissives emit the max light color instead of just not having lighting.
+You can do `return inputColor * faceLightColor;` if you change the lightmap in any way in order to make emissives emit the max light color instead of just not having lighting.
 
 ### NOTICE
 This pack probably won't work with Optifine! If it does, good for you! This pack is supposed to be installed in the RESOURCE PACKS folder, using vanilla Minecraft on 1.18.1, because it is a RESOURCE PACK. If there's still a bug after doing everything correctly, report it in the issues tab at https://github.com/ShockMicro/VanillaDynamicEmissives/issues.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Translucent textures require a bit more work. Check the example for ice to get a
 `return inputColor;` means you're returning the color of the texture without any lighting applied. This is used for making something fully emissive.
 `return apply_partial_emissivity();` means the blocks with that alpha are only partially emissive, tinting it with a specific color of light. You can find a handy link to a table of light colors here: https://minecraft.fandom.com/wiki/Light?file=1.9_lighting_curves_%2528gamma%253D0%2529.png. Remember, colors in OpenGL are formatted as RGB values from 0 to 1!
 `return inputColor * lightColor;` means you're simply returning the texture with its proper lighting. This is the default case.
-You can do `return inputColor * faceLightColor;` if you change the lightmap in any way in order to make emissives emit the max light color instead of just not having lighting.
 
 ### NOTICE
-This pack probably won't work with Optifine! If it does, good for you! This pack is supposed to be installed in the RESOURCE PACKS folder, using vanilla Minecraft on 1.18.1, because it is a RESOURCE PACK. If there's still a bug after doing everything correctly, report it in the issues tab at https://github.com/ShockMicro/VanillaDynamicEmissives/issues.
+This pack probably won't work with Optifine! If it does, good for you! This pack is supposed to be installed in the RESOURCE PACKS folder, using vanilla Minecraft on 1.20.2, because it is a RESOURCE PACK. If there's still a bug after doing everything correctly, report it in the issues tab at https://github.com/ShockMicro/VanillaDynamicEmissives/issues.

--- a/assets/minecraft/shaders/core/particle.fsh
+++ b/assets/minecraft/shaders/core/particle.fsh
@@ -14,17 +14,14 @@ in float vertexDistance;
 in vec2 texCoord0;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 
 out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, vec4(1.0), alpha);
+    if (color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/particle.vsh
+++ b/assets/minecraft/shaders/core/particle.vsh
@@ -19,7 +19,6 @@ out float vertexDistance;
 out vec2 texCoord0;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
@@ -27,6 +26,5 @@ void main() {
     vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
     texCoord0 = UV0;
     vertexColor = Color;
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
 }

--- a/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.fsh
+++ b/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.fsh
@@ -14,16 +14,13 @@ in float vertexDistance;
 in vec2 texCoord0;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.vsh
+++ b/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.vsh
@@ -23,7 +23,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
 out vec2 texCoord1;
 out vec4 normal;
@@ -32,9 +32,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     texCoord0 = UV0;
     texCoord1 = UV1;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);

--- a/assets/minecraft/shaders/core/rendertype_cutout.fsh
+++ b/assets/minecraft/shaders/core/rendertype_cutout.fsh
@@ -11,23 +11,18 @@ uniform float FogEnd;
 uniform vec4 FogColor;
 
 in float vertexDistance;
-in float dimension;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
-in vec3 faceLightingNormal;
 in vec4 normal;
 
 out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-	color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha) / face_lighting_check(faceLightingNormal, alpha, dimension);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_cutout.vsh
+++ b/assets/minecraft/shaders/core/rendertype_cutout.vsh
@@ -18,12 +18,10 @@ uniform int FogShape;
 uniform vec3 ChunkOffset;
 
 out float vertexDistance;
-out float dimension;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
-out vec3 faceLightingNormal;
 out vec4 normal;
 
 void main() {
@@ -31,11 +29,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, pos, FogShape);
-	dimension = get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0)));
-    vertexColor = Color;
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = get_block_face_lighting(Normal, get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0))));
+    vertexColor = Color / faceLightColor;
     texCoord0 = UV0;
-	faceLightingNormal = Normal;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/core/rendertype_cutout_mipped.fsh
+++ b/assets/minecraft/shaders/core/rendertype_cutout_mipped.fsh
@@ -11,23 +11,18 @@ uniform float FogEnd;
 uniform vec4 FogColor;
 
 in float vertexDistance;
-in float dimension;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
-in vec3 faceLightingNormal;
 in vec4 normal;
 
 out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-	color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha) / face_lighting_check(faceLightingNormal, alpha, dimension);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.5) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.5) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_cutout_mipped.vsh
+++ b/assets/minecraft/shaders/core/rendertype_cutout_mipped.vsh
@@ -18,12 +18,10 @@ uniform int FogShape;
 uniform vec3 ChunkOffset;
 
 out float vertexDistance;
-out float dimension;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
-out vec3 faceLightingNormal;
 out vec4 normal;
 
 void main() {
@@ -31,11 +29,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, pos, FogShape);
-	dimension = get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0)));
-    vertexColor = Color;
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = get_block_face_lighting(Normal, get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0))));
+    vertexColor = Color / faceLightColor;
     texCoord0 = UV0;
-	faceLightingNormal = Normal;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
@@ -24,11 +24,8 @@ void main() {
     vec4 color = texture(Sampler0, texCoord0);
     color *= vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout.vsh
@@ -24,7 +24,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec4 overlayColor;
 out vec2 texCoord0;
 out vec4 normal;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     overlayColor = texelFetch(Sampler1, UV1, 0);
     texCoord0 = UV0;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
@@ -24,11 +24,8 @@ void main() {
     vec4 color = texture(Sampler0, texCoord0);
     color *= vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.vsh
@@ -24,7 +24,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec4 overlayColor;
 out vec2 texCoord0;
 out vec4 normal;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     overlayColor = texelFetch(Sampler1, UV1, 0);
     texCoord0 = UV0;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
@@ -24,11 +24,8 @@ void main() {
     vec4 color = texture(Sampler0, texCoord0);
     color *= vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.vsh
@@ -24,7 +24,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec4 overlayColor;
 out vec2 texCoord0;
 out vec4 normal;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     overlayColor = texelFetch(Sampler1, UV1, 0);
     texCoord0 = UV0;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);

--- a/assets/minecraft/shaders/core/rendertype_entity_no_outline.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_no_outline.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
 in vec4 normal;
 
@@ -21,8 +21,7 @@ out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_no_outline.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_no_outline.vsh
@@ -22,7 +22,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
 out vec4 normal;
 
@@ -30,9 +30,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     texCoord0 = UV0;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_solid.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_solid.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
@@ -23,8 +23,7 @@ out vec4 fragColor;
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_solid.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_solid.vsh
@@ -24,7 +24,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec4 overlayColor;
 out vec2 texCoord0;
 out vec4 normal;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     overlayColor = texelFetch(Sampler1, UV1, 0);
     texCoord0 = UV0;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);

--- a/assets/minecraft/shaders/core/rendertype_entity_translucent.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_translucent.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
@@ -24,11 +24,8 @@ void main() {
     vec4 color = texture(Sampler0, texCoord0);
     color *= vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_translucent.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_translucent.vsh
@@ -24,7 +24,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec4 overlayColor;
 out vec2 texCoord0;
 out vec4 normal;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     overlayColor = texelFetch(Sampler1, UV1, 0);
     texCoord0 = UV0;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);

--- a/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.fsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
 in vec2 texCoord1;
 in vec4 normal;
@@ -22,11 +22,8 @@ out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
+++ b/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
@@ -23,7 +23,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
 out vec2 texCoord1;
 out vec2 texCoord2;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     texCoord0 = UV0;
     texCoord1 = UV1;
     texCoord2 = UV2;

--- a/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.fsh
+++ b/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.fsh
@@ -13,7 +13,7 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
 in vec2 texCoord1;
 in vec4 normal;
@@ -22,11 +22,8 @@ out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-    color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha);
-	color.a = remap_alpha(alpha) / 255.0;
-    if (color.a < 0.1) {
-        discard;
-    }
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.vsh
+++ b/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.vsh
@@ -23,7 +23,7 @@ uniform vec3 Light1_Direction;
 out float vertexDistance;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
 out vec2 texCoord1;
 out vec2 texCoord2;
@@ -33,9 +33,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
-    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
     texCoord0 = UV0;
     texCoord1 = UV1;
     texCoord2 = UV2;

--- a/assets/minecraft/shaders/core/rendertype_solid.fsh
+++ b/assets/minecraft/shaders/core/rendertype_solid.fsh
@@ -11,20 +11,17 @@ uniform float FogEnd;
 uniform vec4 FogColor;
 
 in float vertexDistance;
-in float dimension;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
-in vec3 faceLightingNormal;
 in vec4 normal;
 
 out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-	color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha) / face_lighting_check(faceLightingNormal, alpha, dimension);
-	color.a = remap_alpha(alpha) / 255.0;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_solid.vsh
+++ b/assets/minecraft/shaders/core/rendertype_solid.vsh
@@ -18,12 +18,10 @@ uniform int FogShape;
 uniform vec3 ChunkOffset;
 
 out float vertexDistance;
-out float dimension;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
-out vec3 faceLightingNormal;
 out vec4 normal;
 
 void main() {
@@ -31,11 +29,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, pos, FogShape);
-	dimension = get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0)));
-    vertexColor = Color;
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = get_block_face_lighting(Normal, get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0))));
+    vertexColor = Color / faceLightColor;
     texCoord0 = UV0;
-	faceLightingNormal = Normal;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/core/rendertype_translucent.fsh
+++ b/assets/minecraft/shaders/core/rendertype_translucent.fsh
@@ -11,20 +11,17 @@ uniform float FogEnd;
 uniform vec4 FogColor;
 
 in float vertexDistance;
-in float dimension;
 in vec4 vertexColor;
 in vec4 lightColor;
-in vec4 maxLightColor;
+in vec4 faceLightColor;
 in vec2 texCoord0;
-in vec3 faceLightingNormal;
 in vec4 normal;
 
 out vec4 fragColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
-	float alpha = textureLod(Sampler0, texCoord0, 0.0).a * 255.0;
-	color = make_emissive(color, lightColor, maxLightColor, vertexDistance, alpha) / face_lighting_check(faceLightingNormal, alpha, dimension);
-	color.a = remap_alpha(alpha) / 255.0;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_translucent.vsh
+++ b/assets/minecraft/shaders/core/rendertype_translucent.vsh
@@ -18,12 +18,10 @@ uniform int FogShape;
 uniform vec3 ChunkOffset;
 
 out float vertexDistance;
-out float dimension;
 out vec4 vertexColor;
 out vec4 lightColor;
-out vec4 maxLightColor;
+out vec4 faceLightColor;
 out vec2 texCoord0;
-out vec3 faceLightingNormal;
 out vec4 normal;
 
 void main() {
@@ -31,11 +29,9 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
     vertexDistance = fog_distance(ModelViewMat, pos, FogShape);
-	dimension = get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0)));
-    vertexColor = Color;
-	lightColor = minecraft_sample_lightmap(Sampler2, UV2);
-	maxLightColor = minecraft_sample_lightmap(Sampler2, ivec2(240.0, 240.0));
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = get_block_face_lighting(Normal, get_dimension(minecraft_sample_lightmap(Sampler2, ivec2(0.0, 0.0))));
+    vertexColor = Color / faceLightColor;
     texCoord0 = UV0;
-	faceLightingNormal = Normal;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/include/emissive_utils.glsl
+++ b/assets/minecraft/shaders/include/emissive_utils.glsl
@@ -65,7 +65,7 @@ vec4 get_block_face_lighting(vec3 normal, float dimension) {
 
 bool face_lighting_check(int inputAlpha) {
 
-    if (inputAlpha == 250) return false; // Checks for alpha 250, and returns that this face should not be lit. Used in the example pack for lime concrete.
+    if (inputAlpha == 252) return false; // Checks for alpha 252, and returns that this face should not be lit. Used in the example pack for redstone ore and the zombie's eyes.
 
     return true; // A face should be lit by default
 }

--- a/assets/minecraft/shaders/include/emissive_utils.glsl
+++ b/assets/minecraft/shaders/include/emissive_utils.glsl
@@ -66,6 +66,7 @@ vec4 get_block_face_lighting(vec3 normal, float dimension) {
 bool face_lighting_check(int inputAlpha) {
 
     if (inputAlpha == 252) return false; // Checks for alpha 252, and returns that this face should not be lit. Used in the example pack for redstone ore and the zombie's eyes.
+    if (inputAlpha == 250) return false; // Used in the example pack for lime concrete.
 
     return true; // A face should be lit by default
 }
@@ -92,7 +93,6 @@ vec4 make_emissive(vec4 inputColor, vec4 lightColor, vec4 faceLightColor, int in
 
     if (inputAlpha == 252) return inputColor; // Checks for alpha 252 and just returns the input color if it is. Used in the example pack for redstone ore and the zombie's eyes.
     if (inputAlpha == 251) return apply_partial_emissivity(inputColor, lightColor, vec3(0.411, 0.345, 0.388)); // Used in the example pack for ice.
-    if (inputAlpha == 250) return inputColor; // You can copy & this line and change the function to add a new emissive type. Used in the example pack for lime concrete. 
     
     return inputColor * lightColor; // If none of the pixels are supposed to be emissive, then it adds the light.
 }

--- a/assets/minecraft/shaders/include/emissive_utils.glsl
+++ b/assets/minecraft/shaders/include/emissive_utils.glsl
@@ -87,7 +87,7 @@ float remap_alpha(int inputAlpha) {
 
 vec4 make_emissive(vec4 inputColor, vec4 lightColor, vec4 faceLightColor, int inputAlpha) {
 
-    if(face_lighting_check(inputAlpha)) lightColor *= faceLightColor; // Applies the face lighting if the face should be lit
+    if(face_lighting_check(inputAlpha)) inputColor *= faceLightColor; // Applies the face lighting if the face should be lit
     inputColor.a = remap_alpha(inputAlpha) / 255.0; // Remap the alpha value
 
     if (inputAlpha == 252) return inputColor; // Checks for alpha 252 and just returns the input color if it is. Used in the example pack for redstone ore and the zombie's eyes.

--- a/assets/minecraft/shaders/include/emissive_utils.glsl
+++ b/assets/minecraft/shaders/include/emissive_utils.glsl
@@ -2,101 +2,97 @@
 
 // Checking for the exact alpha value breaks things, so I use this function to cut down on space while also making it work better.
 
-bool check_alpha(float textureAlpha, float targetAlpha) {
+bool compare_floats(float a, float b) {
 	
-	float targetLess = targetAlpha - 0.01;
-	float targetMore = targetAlpha + 0.01;
-	return (textureAlpha > targetLess && textureAlpha < targetMore);
+	float targetLess = a - 0.01;
+	float targetMore = a + 0.01;
+	return (b > targetLess && b < targetMore);
 	
 }
-
 
 // For cases in which you want something to have a lower light level, but still be bright when in light.
 
 vec4 apply_partial_emissivity(vec4 inputColor, vec4 originalLightColor, vec3 minimumLightColor) {
-	
-	vec4 newLightColor = originalLightColor;
-	newLightColor.r = max(originalLightColor.r, minimumLightColor.r);
-	newLightColor.g = max(originalLightColor.g, minimumLightColor.g);
-	newLightColor.b = max(originalLightColor.b, minimumLightColor.b);
-	return inputColor * newLightColor;
-	
-}
-
-
-// The meat and bones of the pack, does all the work for making things emissive.
-
-vec4 make_emissive(vec4 inputColor, vec4 lightColor, vec4 maxLightColor, float vertexDistance, float inputAlpha) {
-	
-	if (vertexDistance > 800) return inputColor; // Vertex Distance > 800 generally means an object is in the UI, which we don't want to affect.
-	
-	if (check_alpha(inputAlpha, 252.0)) return inputColor; // Checks for alpha 252 and just returns the input color if it is. Used in the example pack for redstone ore and the zombie's eyes.
-	else if (check_alpha(inputAlpha, 251.0)) return apply_partial_emissivity(inputColor, lightColor, vec3(0.411, 0.345, 0.388)); // Used in the example pack for ice.
-	else if (check_alpha(inputAlpha, 250.0)) return inputColor; // You can copy & this line and change the function to add a new emissive type. Used in the example pack for lime concrete. 
-	
-	else return inputColor * lightColor; // If none of the pixels are supposed to be emissive, then it adds the light.
-	
+    
+    vec4 newLightColor = originalLightColor;
+    newLightColor.r = max(originalLightColor.r, minimumLightColor.r);
+    newLightColor.g = max(originalLightColor.g, minimumLightColor.g);
+    newLightColor.b = max(originalLightColor.b, minimumLightColor.b);
+    return inputColor * newLightColor;
+    
 }
 
 
 // Gets the dimension that an object is in, -1 for The Nether, 0 for The Overworld, 1 for The End.
 
 float get_dimension(vec4 minLightColor) {
-	
-	if (minLightColor.r == minLightColor.g && minLightColor.g == minLightColor.b) return 0.0; // Shadows are grayscale in The Overworld
-	else if (minLightColor.r > minLightColor.g) return -1.0; // Shadows are more red in The Nether
-	else return 1.0; // Shadows are slightly green in The End
-	
+    
+    if (minLightColor.r == minLightColor.g && minLightColor.g == minLightColor.b) return 0.0; // Shadows are grayscale in The Overworld
+    if (minLightColor.r > minLightColor.g) return -1.0; // Shadows are more red in The Nether
+    
+    return 1.0; // Shadows are slightly green in The End
 }
-
 
 // Gets the face lighting of a block. Credits to Venaxsys for the original function.
 
-vec4 get_face_lighting(vec3 normal, float dimension) { 
-	
-	vec4 faceLighting = vec4(1.0, 1.0, 1.0, 1.0);
-	vec3 absNormal = abs(normal);
-	float top = 229.0 / 255.0;
-	float bottom = 127.0 / 255.0;
-	float east = 153.0 / 255.0;
-	float north = 204.0 / 255.0;
-	
-	// Top (only required in the Nether)
-	if (normal.y > normal.z && normal.y > normal.x && check_alpha(dimension, -1.0)) faceLighting = vec4(top, top, top, 1.0); // It's not really checking the alpha but I'm too stubborn to change the function name
-	
-	// Bottom
-	if (normal.y < normal.z && normal.y < normal.x && !check_alpha(dimension, -1.0)) faceLighting = vec4(bottom, bottom, bottom, 1.0);
-	else if (normal.y < normal.z && normal.y < normal.x && check_alpha(dimension, -1.0)) faceLighting = vec4(top, top, top, 1.0);
+vec4 get_block_face_lighting(vec3 normal, float dimension) { 
+    
+    vec4 faceLighting = vec4(1.0, 1.0, 1.0, 1.0);
+    vec3 absNormal = abs(normal);
+    float top = 229.0 / 255.0;
+    float bottom = 127.0 / 255.0;
+    float east = 153.0 / 255.0;
+    float north = 204.0 / 255.0;
+    
+    // Top (only required in the Nether)
+    if (normal.y > normal.z && normal.y > normal.x && compare_floats(dimension, -1.0)) faceLighting = vec4(top, top, top, 1.0); // It's not really checking the alpha but I'm too stubborn to change the function name
+    
+    // Bottom
+    if (normal.y < normal.z && normal.y < normal.x && !compare_floats(dimension, -1.0)) faceLighting = vec4(bottom, bottom, bottom, 1.0);
+    else if (normal.y < normal.z && normal.y < normal.x && compare_floats(dimension, -1.0)) faceLighting = vec4(top, top, top, 1.0);
 
-	// East-West
-	if (absNormal.x > absNormal.z && absNormal.x > absNormal.y) faceLighting = vec4(east, east, east, 1.0);
+    // East-West
+    if (absNormal.x > absNormal.z && absNormal.x > absNormal.y) faceLighting = vec4(east, east, east, 1.0);
 
-	// North-South
-	if (absNormal.z > absNormal.x && absNormal.z > absNormal.y) faceLighting = vec4(north, north, north, 1.0);
+    // North-South
+    if (absNormal.z > absNormal.x && absNormal.z > absNormal.y) faceLighting = vec4(north, north, north, 1.0);
 
-	return faceLighting;
+    return faceLighting;
 }
 
 
-// Checks the alpha and removes face lighting if required.
+// Checks if the face should have lighting.
 
-vec4 face_lighting_check(vec3 normal, float inputAlpha, float dimension) {
+bool face_lighting_check(int inputAlpha) {
 
-	if (check_alpha(inputAlpha, 250.0)) return get_face_lighting(normal, dimension); // Checks for alpha 250, and runs it through the remove_face_lighting() function if it is. Used in the example pack for lime concrete.
-	else return vec4(1.0, 1.0, 1.0, 1.0); // If the block doesn't need to have its face lighting removed, returns 1.0 so nothing gets divided.
-	
+    if (inputAlpha == 250) return false; // Checks for alpha 250, and returns that this face should not be lit. Used in the example pack for lime concrete.
+
+    return true; // A face should be lit by default
 }
 
 
 // Makes sure transparent things don't become solid and vice versa.
 
-float remap_alpha(float inputAlpha) {
-	
-	if (check_alpha(inputAlpha, 252.0)) return 255.0; // Checks for alpha 252 and converts all pixels of that to alpha 255. Used in the example pack for redstone ore and the zombie's eyes.
-	else if (check_alpha(inputAlpha, 251.0)) return 190.0; // You can copy & paste this line and change the values to make any transparent block work with this pack. Used in the example pack for ice.
-	else if (check_alpha(inputAlpha, 250.0)) return 255.0; // Used in the example pack for lime concrete.
-	
-	else return inputAlpha; // If a pixel doesn't need to have its alpha changed then it simply does not change.
-	
+float remap_alpha(int inputAlpha) {
+    
+    if (inputAlpha == 252) return 255.0; // Checks for alpha 252 and converts all pixels of that to alpha 255. Used in the example pack for redstone ore and the zombie's eyes.
+    if (inputAlpha == 251) return 190.0; // You can copy & paste this line and change the values to make any transparent block work with this pack. Used in the example pack for ice.
+    if (inputAlpha == 250) return 255.0; // Used in the example pack for lime concrete.
+    
+    return inputAlpha; // If a pixel doesn't need to have its alpha changed then it simply does not change.
 }
 
+
+// The meat and bones of the pack, does all the work for making things emissive.
+
+vec4 make_emissive(vec4 inputColor, vec4 lightColor, vec4 faceLightColor, int inputAlpha) {
+
+    if(face_lighting_check(inputAlpha)) lightColor *= faceLightColor; // Applies the face lighting if the face should be lit
+    inputColor.a = remap_alpha(inputAlpha) / 255.0; // Remap the alpha value
+
+    if (inputAlpha == 252) return inputColor; // Checks for alpha 252 and just returns the input color if it is. Used in the example pack for redstone ore and the zombie's eyes.
+    if (inputAlpha == 251) return apply_partial_emissivity(inputColor, lightColor, vec3(0.411, 0.345, 0.388)); // Used in the example pack for ice.
+    if (inputAlpha == 250) return inputColor; // You can copy & this line and change the function to add a new emissive type. Used in the example pack for lime concrete. 
+    
+    return inputColor * lightColor; // If none of the pixels are supposed to be emissive, then it adds the light.
+}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack": {
-      "pack_format": 8,
+      "pack_format": 18,
       "description": "Allows for dynamic emissive textures in vanilla."
    }
 }


### PR DESCRIPTION
did a bunch of stuff
- update to 1.20.2
- face lighting removal works on entities now
- the alpha value that everyone uses (252) removes face lighting
- the lime concrete example is no longer emissive, but does get rid of face lighting
- removed a few unused variables

changed the examples because those two types of emissives are the most common ones i've encountered