### PR TITLE
SteamOS 3.0 (SteamDeck) Fix

### DIFF
--- a/assets/minecraft/shaders/include/emissive_utils.glsl
+++ b/assets/minecraft/shaders/include/emissive_utils.glsl
@@ -80,7 +80,7 @@ float remap_alpha(int inputAlpha) {
     if (inputAlpha == 251) return 190.0; // You can copy & paste this line and change the values to make any transparent block work with this pack. Used in the example pack for ice.
     if (inputAlpha == 250) return 255.0; // Used in the example pack for lime concrete.
     
-    return inputAlpha; // If a pixel doesn't need to have its alpha changed then it simply does not change.
+    return float(inputAlpha); // If a pixel doesn't need to have its alpha changed then it simply does not change.
 }
 
 


### PR DESCRIPTION
When applying the resource pack on a SteamDeck, the error `return 'with wrong type int, in function remap_alpha' returning float` would throw. 

Casting `inputValue` to a `float` in the `remap_alpha()` function fixed this! :D